### PR TITLE
Fix log levels order

### DIFF
--- a/logger.lua
+++ b/logger.lua
@@ -1,26 +1,26 @@
 local DEFAULT_LEVELS = {
-	-- The lowest possible rank and is intended to turn off logging.
-	"OFF",
-	-- Severe errors that cause premature termination. Expect these to be
-	-- immediately visible on a status console.
-	"FATAL",
-	-- Other runtime errors or unexpected conditions. Expect these to be
-	-- immediately visible on a status console.
-	"ERROR",
-	-- Use of deprecated APIs, poor use of API, 'almost' errors, other runtime
-	-- situations that are undesirable or unexpected, but not necessarily
-	-- "wrong". Expect these to be immediately visible on a status console.
-	"WARN",
+    -- Most detailed information. Expect these to be written to logs only.
+	"TRACE",
+    -- Detailed information on the flow through the system. Expect these to be
+	-- written to logs only. Generally speaking, most lines logged by your
+	-- application should be written as DEBUG.
+	"DEBUG",
 	-- Interesting runtime events (startup/shutdown). Expect these to be
 	-- immediately visible on a console, so be conservative and keep to a
 	-- minimum.
 	"INFO",
-	-- Detailed information on the flow through the system. Expect these to be
-	-- written to logs only. Generally speaking, most lines logged by your
-	-- application should be written as DEBUG.
-	"DEBUG",
-	-- Most detailed information. Expect these to be written to logs only.
-	"TRACE"
+    -- Use of deprecated APIs, poor use of API, 'almost' errors, other runtime
+	-- situations that are undesirable or unexpected, but not necessarily
+	-- "wrong". Expect these to be immediately visible on a status console.
+	"WARN",
+    -- Other runtime errors or unexpected conditions. Expect these to be
+	-- immediately visible on a status console.
+	"ERROR",
+    -- Severe errors that cause premature termination. Expect these to be
+	-- immediately visible on a status console.
+	"FATAL",
+    -- The lowest possible rank and is intended to turn off logging.
+	"OFF"
 }
 
 local function indexof(val, t)
@@ -110,7 +110,7 @@ return function(append, settings)
 		end
 		-- print('logger.lua debug: current level is ' .. self.level .. ' (order = ' .. self.level_order .. ')')
 		-- print('logger.lua debug: testing against ' .. order)
-		if order <= self.level_order then
+		if order >= self.level_order then
 			return self:append(level, msg)
 		else
 			return


### PR DESCRIPTION
Hi, 

In the `DEFAULT_LEVELS` table levels were in a backward order, i.e. `TRACE` had index 7 and `OFF` had 1.

This changes the order of the levels according to `README` and swaps level  order comparison in a `log` function.